### PR TITLE
Improved ref hashes

### DIFF
--- a/__tests__/database/CollectionReference.test.js
+++ b/__tests__/database/CollectionReference.test.js
@@ -10,7 +10,10 @@ describe("CollectionReference", () => {
       const collectionRef = new CollectionReference("users", databaseRef);
       expect(collectionRef.name).toBe("users");
       expect(collectionRef.hash).toBe(
-        new Buffer("default/default/users").toString("base64")
+        new Buffer(
+          "default/default/users?q=" +
+            encodeURIComponent(JSON.stringify(collectionRef.query))
+        ).toString("base64")
       );
     });
   });

--- a/__tests__/database/CollectionReference.test.js
+++ b/__tests__/database/CollectionReference.test.js
@@ -1,16 +1,25 @@
+const AppReference = require("../../app/AppReference");
+const DatabaseReference = require("../../database/DatabaseReference");
 const CollectionReference = require("../../database/CollectionReference");
 
 describe("CollectionReference", () => {
   describe("constructor", () => {
     it("should construct a CollectionReference", () => {
-      const collectionRef = new CollectionReference("users");
+      const appRef = new AppReference("default");
+      const databaseRef = new DatabaseReference("default", appRef);
+      const collectionRef = new CollectionReference("users", databaseRef);
       expect(collectionRef.name).toBe("users");
+      expect(collectionRef.hash).toBe(
+        new Buffer("default/default/users").toString("base64")
+      );
     });
   });
 
   describe("doc", () => {
     it("should return a DocumentReference", () => {
-      const collectionRef = new CollectionReference("users");
+      const appRef = new AppReference("default");
+      const databaseRef = new DatabaseReference("default", appRef);
+      const collectionRef = new CollectionReference("users", databaseRef);
       const documentRef = collectionRef.doc("10");
       expect(documentRef.id).toBe("10");
       expect(documentRef.collection).toEqual(collectionRef);

--- a/__tests__/database/DocumentReference.test.js
+++ b/__tests__/database/DocumentReference.test.js
@@ -1,13 +1,20 @@
+const AppReference = require("../../app/AppReference");
+const DatabaseReference = require("../../database/DatabaseReference");
 const CollectionReference = require("../../database/CollectionReference");
 const DocumentReference = require("../../database/DocumentReference");
 
 describe("DocumentReference", () => {
   describe("constructor", () => {
     it("should construct a DocumentReference", () => {
-      const collectionRef = new CollectionReference("users");
+      const appRef = new AppReference("default");
+      const databaseRef = new DatabaseReference("default", appRef);
+      const collectionRef = new CollectionReference("users", databaseRef);
       const ref = new DocumentReference("10", collectionRef);
       expect(ref.id).toBe("10");
       expect(ref.collection).toBe(collectionRef);
+      expect(ref.hash).toBe(
+        new Buffer("default/default/users/10").toString("base64")
+      );
     });
   });
 

--- a/database/CollectionReference.js
+++ b/database/CollectionReference.js
@@ -1,3 +1,4 @@
+const qs = require("querystring");
 const DocumentReference = require("./DocumentReference");
 
 class CollectionReference {
@@ -9,7 +10,9 @@ class CollectionReference {
 
   get hash() {
     return new Buffer(
-      `${this.database.app.name}/${this.database.name}/${this.name}`
+      `${this.database.app.name}/${this.database.name}/${
+        this.name
+      }?q=${encodeURIComponent(JSON.stringify(this.query))}`
     ).toString("base64");
   }
 

--- a/database/CollectionReference.js
+++ b/database/CollectionReference.js
@@ -7,6 +7,12 @@ class CollectionReference {
     this.query = { limit: 1000, orderBy: [], where: [] };
   }
 
+  get hash() {
+    return new Buffer(
+      `${this.database.app.name}/${this.database.name}/${this.name}`
+    ).toString("base64");
+  }
+
   doc(id) {
     return new DocumentReference(id, this);
   }

--- a/database/DocumentReference.js
+++ b/database/DocumentReference.js
@@ -2,7 +2,14 @@ class DocumentReference {
   constructor(id, collection) {
     this.id = id;
     this.collection = collection;
-    this.hash = this.collection + "/" + this.id;
+  }
+
+  get hash() {
+    return new Buffer(
+      `${this.collection.database.name}/${this.collection.database.name}/${
+        this.collection.name
+      }/${this.id}`
+    ).toString("base64");
   }
 }
 


### PR DESCRIPTION
Hashes now properly include the app name and database name, as well as information about the query on CollectionReferences. This ensures they are actually properly unique, and not erroneously re-used.